### PR TITLE
Feat: make prefix changeable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ A Discord bot to handle League of Legends in-house games, with role queue, match
 
      - You can add the environment variable `INHOUSE_BOT_TEST=1` to the bot’s variables and it will add a few `!test` commands
 
+     - You can add the environment variable `COMMAND_PREFIX` to customize the prefix of the bot (will default to `!`).
+
 - Run `docker-compose up -d` and your bot should be up and running!
 
     - If you also added the `adminer` service, you can use http://localhost:8080/ to manage the database

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A Discord bot to handle League of Legends in-house games, with role queue, match
 
      - You can add the environment variable `INHOUSE_BOT_TEST=1` to the bot’s variables and it will add a few `!test` commands
 
-     - You can add the environment variable `COMMAND_PREFIX` to customize the prefix of the bot (will default to `!`).
+     - You can add the environment variable `INHOUSE_BOT_COMMAND_PREFIX` to customize the prefix of the bot (will default to `!`).
 
 - Run `docker-compose up -d` and your bot should be up and running!
 

--- a/inhouse_bot/cogs/admin_cog.py
+++ b/inhouse_bot/cogs/admin_cog.py
@@ -6,6 +6,8 @@ from discord.ext.commands import guild_only
 
 from inhouse_bot import game_queue, matchmaking_logic
 from inhouse_bot.database_orm import session_scope
+from inhouse_bot.common_utils.constants import PREFIX
+from inhouse_bot.common_utils.docstring import doc
 from inhouse_bot.common_utils.get_last_game import get_last_game
 from inhouse_bot.inhouse_bot import InhouseBot
 from inhouse_bot.queue_channel_handler import queue_channel_handler
@@ -22,10 +24,8 @@ class AdminCog(commands.Cog, name="Admin"):
 
     @commands.group(case_insensitive=True)
     @commands.has_permissions(administrator=True)
+    @doc(f"Admin functions, use {PREFIX}help admin for a complete list")
     async def admin(self, ctx: commands.Context):
-        """
-        Admin functions, use !help admin for a complete list
-        """
         if ctx.invoked_subcommand is None:
             await ctx.send(
                 f"The accepted subcommands are "

--- a/inhouse_bot/cogs/admin_cog.py
+++ b/inhouse_bot/cogs/admin_cog.py
@@ -105,7 +105,7 @@ class AdminCog(commands.Cog, name="Admin"):
             await ctx.send(f"Current channel marked as a ranking channel")
 
         else:
-            await ctx.send("Accepted values for !admin mark are QUEUE and RANKING")
+            await ctx.send(f"Accepted values for {PREFIX}admin mark are QUEUE and RANKING")
 
     @admin.command()
     @guild_only()

--- a/inhouse_bot/cogs/queue_cog.py
+++ b/inhouse_bot/cogs/queue_cog.py
@@ -6,6 +6,8 @@ from discord.ext import commands
 from inhouse_bot import game_queue
 from inhouse_bot import matchmaking_logic
 
+from inhouse_bot.common_utils.constants import PREFIX
+from inhouse_bot.common_utils.docstring import doc
 from inhouse_bot.common_utils.emoji_and_thumbnails import get_role_emoji
 from inhouse_bot.common_utils.fields import RoleConverter
 from inhouse_bot.common_utils.get_last_game import get_last_game
@@ -155,14 +157,7 @@ class QueueCog(commands.Cog, name="Queue"):
 
     @commands.command()
     @queue_channel_only()
-    async def queue(
-        self,
-        ctx: commands.Context,
-        role: RoleConverter(),
-        duo: discord.Member = None,
-        duo_role: RoleConverter() = None,
-    ):
-        """
+    @doc(f"""
         Adds you to the current channel’s queue for the given role
 
         To duo queue, add @player role at the end (cf examples)
@@ -170,11 +165,18 @@ class QueueCog(commands.Cog, name="Queue"):
         Roles are TOP, JGL, MID, BOT/ADC, and SUP
 
         Example:
-            !queue SUP
-            !queue bot
-            !queue adc
-            !queue adc @CoreJJ support
-        """
+            {PREFIX}queue SUP
+            {PREFIX}queue bot
+            {PREFIX}queue adc
+            {PREFIX}queue adc @CoreJJ support
+    """)
+    async def queue(
+        self,
+        ctx: commands.Context,
+        role: RoleConverter(),
+        duo: discord.Member = None,
+        duo_role: RoleConverter() = None,
+    ):
         # Checking if the last game of this player got cancelled
         #   If so, we put them in the queue in front of other players
         jump_ahead = False
@@ -238,34 +240,33 @@ class QueueCog(commands.Cog, name="Queue"):
 
     @commands.command(aliases=["leave_queue", "stop"])
     @queue_channel_only()
-    async def leave(
-        self, ctx: commands.Context,
-    ):
-        """
+    @doc(f"""
         Removes you from the queue in the current channel
 
         Example:
-            !leave
-            !leave_queue
-        """
-
+            {PREFIX}leave
+            {PREFIX}leave_queue
+    """)
+    async def leave(
+        self, ctx: commands.Context,
+    ):
         game_queue.remove_player(player_id=ctx.author.id, channel_id=ctx.channel.id)
 
         await queue_channel_handler.update_queue_channels(bot=self.bot, server_id=ctx.guild.id)
 
     @commands.command(aliases=["win", "wins", "victory"])
     @queue_channel_only()
-    async def won(
-        self, ctx: commands.Context,
-    ):
-        """
+    @doc(f"""
         Scores your last game as a win
 
         Will require validation from at least 6 players in the game
 
         Example:
-            !won
-        """
+            {PREFIX}won
+    """)
+    async def won(
+        self, ctx: commands.Context,
+    ):
         with session_scope() as session:
             # Get the latest game
             game, participant = get_last_game(
@@ -322,17 +323,17 @@ class QueueCog(commands.Cog, name="Queue"):
 
     @commands.command(aliases=["cancel_game"])
     @queue_channel_only()
-    async def cancel(
-        self, ctx: commands.Context,
-    ):
-        """
+    @doc(f"""
         Cancels your ongoing game
 
         Will require validation from at least 6 players in the game
 
         Example:
-            !cancel
-        """
+            {PREFIX}cancel
+    """)
+    async def cancel(
+        self, ctx: commands.Context,
+    ):
         with session_scope() as session:
             # Get the latest game
             game, participant = get_last_game(

--- a/inhouse_bot/cogs/stats_cog.py
+++ b/inhouse_bot/cogs/stats_cog.py
@@ -15,6 +15,8 @@ from discord.ext.commands import guild_only
 import matplotlib
 import matplotlib.pyplot as plt
 
+from inhouse_bot.common_utils.constants import PREFIX
+from inhouse_bot.common_utils.docstring import doc
 from inhouse_bot.common_utils.emoji_and_thumbnails import get_role_emoji, get_rank_emoji
 from inhouse_bot.database_orm import session_scope, GameParticipant, Game, PlayerRating, Player
 from inhouse_bot.common_utils.fields import ChampionNameConverter, RoleConverter
@@ -40,20 +42,19 @@ class StatsCog(commands.Cog, name="Stats"):
 
     @commands.command()
     @guild_only()
+    @doc(f"""
+        Saves the champion you used in your last game
+
+        Older games can be filled with {PREFIX}champion champion_name game_id
+        You can find the ID of the games you played with {PREFIX}history
+
+        Example:
+            {PREFIX}champion riven
+            {PREFIX}champion riven 1
+    """)
     async def champion(
         self, ctx: commands.Context, champion_name: ChampionNameConverter(), game_id: int = None
     ):
-        """
-        Saves the champion you used in your last game
-
-        Older games can be filled with !champion champion_name game_id
-        You can find the ID of the games you played with !history
-
-        Example:
-            !champion riven
-            !champion riven 1
-        """
-
         with session_scope() as session:
             if not game_id:
                 game, participant = get_last_game(
@@ -79,14 +80,14 @@ class StatsCog(commands.Cog, name="Stats"):
         )
 
     @commands.command(aliases=["match_history", "mh"])
-    async def history(self, ctx: commands.Context):
-        # TODO LOW PRIO Add an @ user for admins
-        """
+    @doc(f"""
         Displays your games history
 
         Example:
-            !history
-        """
+            {PREFIX}history
+    """)
+    async def history(self, ctx: commands.Context):
+        # TODO LOW PRIO Add an @ user for admins
 
         with session_scope() as session:
             session.expire_on_commit = False
@@ -121,13 +122,13 @@ class StatsCog(commands.Cog, name="Stats"):
         await pages.start(ctx)
 
     @commands.command(aliases=["mmr", "rank", "rating"])
-    async def stats(self, ctx: commands.Context):
-        """
+    @doc(f"""
         Returns your rank, MMR, and games played
 
         Example:
-            !rank
-        """
+            {PREFIX}rank
+    """)
+    async def stats(self, ctx: commands.Context):
         with session_scope() as session:
             rating_objects = (
                 session.query(
@@ -177,16 +178,16 @@ class StatsCog(commands.Cog, name="Stats"):
 
     @commands.command(aliases=["rankings"])
     @guild_only()
-    async def ranking(self, ctx: commands.Context, role: RoleConverter() = None):
-        """
+    @doc(f"""
         Displays the top players on the server
 
         A role can be supplied to only display the ranking for this role
 
         Example:
-            !ranking
-            !ranking mid
-        """
+            {PREFIX}ranking
+            {PREFIX}ranking mid
+    """)
+    async def ranking(self, ctx: commands.Context, role: RoleConverter() = None):
         ratings = ranking_channel_handler.get_server_ratings(ctx.guild.id, role=role)
 
         if not ratings:

--- a/inhouse_bot/common_utils/constants.py
+++ b/inhouse_bot/common_utils/constants.py
@@ -1,0 +1,3 @@
+import os
+
+PREFIX = os.environ.get("COMMAND_PREFIX") if os.environ.get("COMMAND_PREFIX") else "!"

--- a/inhouse_bot/common_utils/constants.py
+++ b/inhouse_bot/common_utils/constants.py
@@ -1,3 +1,3 @@
 import os
 
-PREFIX = os.environ.get("COMMAND_PREFIX") if os.environ.get("COMMAND_PREFIX") else "!"
+PREFIX = os.environ.get("COMMAND_PREFIX") or "!"

--- a/inhouse_bot/common_utils/constants.py
+++ b/inhouse_bot/common_utils/constants.py
@@ -1,3 +1,3 @@
 import os
 
-PREFIX = os.environ.get("COMMAND_PREFIX") or "!"
+PREFIX = os.environ.get("INHOUSE_BOT_COMMAND_PREFIX") or "!"

--- a/inhouse_bot/common_utils/docstring.py
+++ b/inhouse_bot/common_utils/docstring.py
@@ -1,0 +1,6 @@
+def doc(docstring):
+    def document(func):
+        func.__doc__ = docstring
+        return func
+
+    return document

--- a/inhouse_bot/inhouse_bot.py
+++ b/inhouse_bot/inhouse_bot.py
@@ -8,6 +8,7 @@ from discord.ext import commands
 from discord.ext.commands import NoPrivateMessage
 
 from inhouse_bot import game_queue
+from inhouse_bot.common_utils.constants import PREFIX
 from inhouse_bot.game_queue.queue_handler import SameRolesForDuo
 from inhouse_bot.queue_channel_handler.queue_channel_handler import (
     QueueChannelsOnly,
@@ -27,7 +28,7 @@ class InhouseBot(commands.Bot):
     """
 
     def __init__(self, **options):
-        super().__init__("!", intents=intents, case_insensitive=True, **options)
+        super().__init__(PREFIX, intents=intents, case_insensitive=True, **options)
 
         # Importing locally to allow InhouseBot to be imported in the cogs
         from inhouse_bot.cogs.queue_cog import QueueCog
@@ -75,10 +76,10 @@ class InhouseBot(commands.Bot):
         Custom error command that catches CommandNotFound as well as MissingRequiredArgument for readable feedback
         """
         if isinstance(error, commands.CommandNotFound):
-            await ctx.send(f"Command `{ctx.invoked_with}` not found, use !help to see the commands list")
+            await ctx.send(f"Command `{ctx.invoked_with}` not found, use {PREFIX}help to see the commands list")
 
         elif isinstance(error, commands.MissingRequiredArgument):
-            await ctx.send(f"Arguments missing, use `!help {ctx.invoked_with}` to see the arguments list")
+            await ctx.send(f"Arguments missing, use `{PREFIX}help {ctx.invoked_with}` to see the arguments list")
 
         elif isinstance(error, commands.ConversionError):
             # Conversion errors feedback are handled in my converters
@@ -100,15 +101,15 @@ class InhouseBot(commands.Bot):
             if isinstance(og_error, game_queue.PlayerInGame):
                 await ctx.send(
                     f"Your last game was not scored and you are not allowed to queue at the moment\n"
-                    f"One of the winners can score the game with `!won`, "
-                    f"or players can agree to cancel it with `!cancel`",
+                    f"One of the winners can score the game with `{PREFIX}won`, "
+                    f"or players can agree to cancel it with `{PREFIX}cancel`",
                     delete_after=20,
                 )
 
             elif isinstance(og_error, game_queue.PlayerInReadyCheck):
                 await ctx.send(
                     f"A game has already been found for you and you cannot queue until it is accepted or cancelled\n"
-                    f"If it is a bug, contact an admin and ask them to use `!admin reset` with your name",
+                    f"If it is a bug, contact an admin and ask them to use `{PREFIX}admin reset` with your name",
                     delete_after=20,
                 )
 
@@ -116,7 +117,7 @@ class InhouseBot(commands.Bot):
                 # User-facing error
                 await ctx.send(
                     f"There was an error processing the command\n"
-                    f"Use !help for the commands list or contact server admins for bugs",
+                    f"Use {PREFIX}help for the commands list or contact server admins for bugs",
                 )
 
                 self.logger.error(og_error)
@@ -125,7 +126,7 @@ class InhouseBot(commands.Bot):
             # User-facing error
             await ctx.send(
                 f"There was an error processing the command\n"
-                f"Use !help for the commands list or contact server admins for bugs",
+                f"Use {PREFIX}help for the commands list or contact server admins for bugs",
             )
 
             self.logger.error(error)

--- a/inhouse_bot/queue_channel_handler/queue_channel_handler.py
+++ b/inhouse_bot/queue_channel_handler/queue_channel_handler.py
@@ -7,6 +7,7 @@ from discord.ext import commands
 from discord.ext.commands import Bot
 
 from inhouse_bot import game_queue
+from inhouse_bot.common_utils.constants import PREFIX
 from inhouse_bot.common_utils.embeds import embeds_color
 from inhouse_bot.common_utils.emoji_and_thumbnails import get_role_emoji
 from inhouse_bot.database_orm import session_scope, ChannelInformation
@@ -99,7 +100,7 @@ class QueueChannelHandler:
             embed.add_field(name="Duos", value=", ".join(duos_strings))
 
         embed.set_footer(
-            text="Use !queue [role] to join or !leave to leave | All non-queue messages are deleted"
+            text=f"Use {PREFIX}queue [role] to join or !leave to leave | All non-queue messages are deleted"
         )
 
         message_text = ""


### PR DESCRIPTION
This allows the bots prefix to be changed. 

Helpful in cases where there are multiple bots on the Discord (for example MEE6 will interfere with the !queue command.