### PR TITLE
Add creation of dynamic voice channels

### DIFF
--- a/inhouse_bot/cogs/admin_cog.py
+++ b/inhouse_bot/cogs/admin_cog.py
@@ -12,6 +12,7 @@ from inhouse_bot.common_utils.get_last_game import get_last_game
 from inhouse_bot.inhouse_bot import InhouseBot
 from inhouse_bot.queue_channel_handler import queue_channel_handler
 from inhouse_bot.ranking_channel_handler.ranking_channel_handler import ranking_channel_handler
+from inhouse_bot.voice_channel_handler.voice_channel_handler import remove_voice_channels
 
 
 class AdminCog(commands.Cog, name="Admin"):
@@ -88,6 +89,7 @@ class AdminCog(commands.Cog, name="Admin"):
 
         await ctx.send(f"{member.display_name}’s ongoing game was cancelled and deleted from the database")
         await queue_channel_handler.update_queue_channels(bot=self.bot, server_id=ctx.guild.id)
+        await remove_voice_channels(ctx, game)
 
     @admin.command()
     @guild_only()

--- a/inhouse_bot/cogs/queue_cog.py
+++ b/inhouse_bot/cogs/queue_cog.py
@@ -18,6 +18,7 @@ from inhouse_bot.inhouse_bot import InhouseBot
 from inhouse_bot.queue_channel_handler import queue_channel_handler
 from inhouse_bot.queue_channel_handler.queue_channel_handler import queue_channel_only
 from inhouse_bot.ranking_channel_handler.ranking_channel_handler import ranking_channel_handler
+from inhouse_bot.voice_channel_handler.voice_channel_handler import create_voice_channels, remove_voice_channels
 
 
 class QueueCog(commands.Cog, name="Queue"):
@@ -104,6 +105,9 @@ class QueueCog(commands.Cog, name="Queue"):
                 queue_channel_handler.mark_queue_related_message(
                     await ctx.send(embed=game.get_embed("GAME_ACCEPTED"),)
                 )
+
+                # We create voice channels for each team in this game
+                await create_voice_channels(ctx, game)
 
             elif ready is False:
                 # We remove the player who cancelled
@@ -320,6 +324,9 @@ class QueueCog(commands.Cog, name="Queue"):
 
         matchmaking_logic.score_game_from_winning_player(player_id=ctx.author.id, server_id=ctx.guild.id)
         await ranking_channel_handler.update_ranking_channels(self.bot, ctx.guild.id)
+
+        # If we're here, the game has been scored and the voice channels for this game can be removed
+        await remove_voice_channels(ctx, game)
 
     @commands.command(aliases=["cancel_game"])
     @queue_channel_only()

--- a/inhouse_bot/common_utils/constants.py
+++ b/inhouse_bot/common_utils/constants.py
@@ -1,3 +1,4 @@
 import os
 
 PREFIX = os.environ.get("INHOUSE_BOT_COMMAND_PREFIX") or "!"
+CONFIG_KEYS = ["voice"]

--- a/inhouse_bot/common_utils/get_server_config.py
+++ b/inhouse_bot/common_utils/get_server_config.py
@@ -1,0 +1,36 @@
+from inhouse_bot.common_utils.constants import CONFIG_KEYS
+from inhouse_bot.database_orm import ServerConfig
+from inhouse_bot.database_orm.session.session_handler import session_scope
+
+
+def get_server_config(server_id: int, session) -> ServerConfig:
+    server_config = (
+        session.query(ServerConfig)
+        .select_from(ServerConfig)
+        .filter(ServerConfig.server_id == server_id)
+    ).first() or None
+
+    if server_config is not None:
+        return server_config
+
+    # If server_config doesn't exist for this server_id, we'll create one now and send that back
+    server_config = ServerConfig()
+    server_config.server_id = server_id
+    server_config.config = {}
+    for key in CONFIG_KEYS:
+        server_config.config[key] = False
+
+    session.merge(server_config)
+
+    return server_config
+
+
+def get_server_config_by_key(server_id: int, key: str) -> bool:
+    """
+    By utilizing this function, we ensure that keys that don't yet exist in the config
+    will return False.
+    """
+
+    with session_scope() as session:
+        server_config = get_server_config(server_id=server_id, session=session)
+        return server_config.config.get(key, False)

--- a/inhouse_bot/database_orm/__init__.py
+++ b/inhouse_bot/database_orm/__init__.py
@@ -4,6 +4,7 @@ from inhouse_bot.database_orm.tables.game import Game
 from inhouse_bot.database_orm.tables.game_participant import GameParticipant
 from inhouse_bot.database_orm.tables.player import Player
 from inhouse_bot.database_orm.tables.player_rating import PlayerRating
+from inhouse_bot.database_orm.tables.server_config import ServerConfig
 from inhouse_bot.database_orm.tables.queue_player import QueuePlayer
 from inhouse_bot.database_orm.tables.channel_information import ChannelInformation
 

--- a/inhouse_bot/database_orm/tables/server_config.py
+++ b/inhouse_bot/database_orm/tables/server_config.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, BigInteger, Integer, JSON
+from sqlalchemy.ext.mutable import MutableDict
+
+from inhouse_bot.database_orm import bot_declarative_base
+
+
+class ServerConfig(bot_declarative_base):
+    """Table used for persistent server config"""
+
+    __tablename__ = "server_config"
+
+    # Auto-incremented ID field
+    id = Column(Integer, primary_key=True)
+
+    server_id = Column(BigInteger, unique=True)
+
+    config = Column(MutableDict.as_mutable(JSON))

--- a/inhouse_bot/voice_channel_handler/voice_channel_handler.py
+++ b/inhouse_bot/voice_channel_handler/voice_channel_handler.py
@@ -1,0 +1,59 @@
+import discord
+from string import Template
+from discord.ext import commands
+from inhouse_bot.database_orm import Game
+
+VOICE_CATEGORY = '▬▬ Team Voice Chat ▬▬'
+public_channel = '-- Game #$game_id --'
+team_channel = '--> $side Team #$game_id'
+
+
+async def create_voice_channels(ctx: commands.Context, game: Game):
+    """
+    Creates a private voice channel for each team of players in a game and a public
+    voice channel for all to join
+    """
+
+    category = discord.utils.get(ctx.guild.categories, name=VOICE_CATEGORY)
+    # Creates the category for Team Voice Chat if it doesn't exist
+    if category is None:
+        category = await discord.Guild.create_category(ctx.guild, VOICE_CATEGORY)
+
+    # Creates a public channel that also acts as a header for the team voice channels
+    await discord.Guild.create_voice_channel(
+        ctx.guild,
+        name=Template(public_channel).substitute(game_id=game.id),
+        category=category,
+    )
+
+    for side in ("BLUE", "RED"):
+        overwrites = {
+            ctx.guild.default_role: discord.PermissionOverwrite(read_messages=False)
+        }
+
+        for p in getattr(game.teams, side):
+            member = discord.Guild.get_member(ctx.guild, p.id)
+            if member is not None:
+                overwrites[member] = discord.PermissionOverwrite(read_messages=True)
+
+        await discord.Guild.create_voice_channel(
+            ctx.guild,
+            name=Template(team_channel).substitute(side=side.capitalize(), game_id=game.id),
+            category=category,
+            overwrites=overwrites
+        )
+
+
+async def remove_voice_channels(ctx: commands.Context, game: Game):
+    """
+    Removes all voice channels associated with a game
+    """
+
+    for channel in [
+        Template(public_channel).substitute(game_id=game.id),
+        Template(team_channel).substitute(side="Blue", game_id=game.id),
+        Template(team_channel).substitute(side="Red", game_id=game.id)
+    ]:
+        channel_to_del = discord.utils.get(ctx.guild.channels, name=channel)
+        if channel_to_del is not None:
+            await channel_to_del.delete()

--- a/inhouse_bot/voice_channel_handler/voice_channel_handler.py
+++ b/inhouse_bot/voice_channel_handler/voice_channel_handler.py
@@ -1,11 +1,14 @@
+import os
 import discord
 from string import Template
 from discord.ext import commands
+
+from inhouse_bot.common_utils.get_server_config import get_server_config_by_key
 from inhouse_bot.database_orm import Game
 
-VOICE_CATEGORY = '▬▬ Team Voice Chat ▬▬'
-public_channel = '-- Game #$game_id --'
-team_channel = '--> $side Team #$game_id'
+VOICE_CATEGORY = os.getenv('VOICE_CATEGORY', '▬▬ Team Voice Chat ▬▬')
+VOICE_PUBLIC_CHANNEL = os.getenv('VOICE_PUBLIC_CHANNEL', '-- Game #$game_id --')
+VOICE_TEAM_CHANNEL = os.getenv('VOICE_TEAM_CHANNEL', '--> $side Team #$game_id')
 
 
 async def create_voice_channels(ctx: commands.Context, game: Game):
@@ -13,6 +16,9 @@ async def create_voice_channels(ctx: commands.Context, game: Game):
     Creates a private voice channel for each team of players in a game and a public
     voice channel for all to join
     """
+
+    if not get_server_config_by_key(server_id=ctx.guild.id, key="voice"):
+        return
 
     category = discord.utils.get(ctx.guild.categories, name=VOICE_CATEGORY)
     # Creates the category for Team Voice Chat if it doesn't exist
@@ -22,7 +28,7 @@ async def create_voice_channels(ctx: commands.Context, game: Game):
     # Creates a public channel that also acts as a header for the team voice channels
     await discord.Guild.create_voice_channel(
         ctx.guild,
-        name=Template(public_channel).substitute(game_id=game.id),
+        name=Template(VOICE_PUBLIC_CHANNEL).substitute(game_id=game.id),
         category=category,
     )
 
@@ -38,7 +44,7 @@ async def create_voice_channels(ctx: commands.Context, game: Game):
 
         await discord.Guild.create_voice_channel(
             ctx.guild,
-            name=Template(team_channel).substitute(side=side.capitalize(), game_id=game.id),
+            name=Template(VOICE_TEAM_CHANNEL).substitute(side=side.capitalize(), game_id=game.id),
             category=category,
             overwrites=overwrites
         )
@@ -49,10 +55,13 @@ async def remove_voice_channels(ctx: commands.Context, game: Game):
     Removes all voice channels associated with a game
     """
 
+    if not get_server_config_by_key(server_id=ctx.guild.id, key="voice"):
+        return
+
     for channel in [
-        Template(public_channel).substitute(game_id=game.id),
-        Template(team_channel).substitute(side="Blue", game_id=game.id),
-        Template(team_channel).substitute(side="Red", game_id=game.id)
+        Template(VOICE_PUBLIC_CHANNEL).substitute(game_id=game.id),
+        Template(VOICE_TEAM_CHANNEL).substitute(side="Blue", game_id=game.id),
+        Template(VOICE_TEAM_CHANNEL).substitute(side="Red", game_id=game.id)
     ]:
         channel_to_del = discord.utils.get(ctx.guild.channels, name=channel)
         if channel_to_del is not None:


### PR DESCRIPTION
 ### Problem to Solve
 
 Right now, joining voice channels related to a game is a little sloppy. Players have to claim a channel and make sure that only players on their team are inside.
 
 ### Solution
 
 After players have checked in to a game, the bot creates 3 voice channels using the game id. One channel is the public channel, and then a red team channel that only players on the red team can see and join, and a blue team channel that only players on the blue team can see and join.
 
 When the game is scored (or canceled) the bot cleans up these channels.

### Notes

The bot will need the appropriate permissions for managing voice channels. 

Testing for this seems difficult the way testing is currently set up (and with my fresh knowledge of the Discord API), so I did it manually to confirm it worked.