### PR TITLE
Fix session commit bug and update help options

### DIFF
--- a/inhouse_bot/cogs/admin_cog.py
+++ b/inhouse_bot/cogs/admin_cog.py
@@ -139,8 +139,8 @@ class AdminCog(commands.Cog, name="Admin"):
             info = ""
             for c in CONFIG_OPTIONS:
                 info = f"{info}\n**{c[0]}**: {c[1]}"
-                await ctx.send(info)
-                return
+            await ctx.send(info)
+            return
 
         options = {
             'ON': True,

--- a/inhouse_bot/common_utils/constants.py
+++ b/inhouse_bot/common_utils/constants.py
@@ -1,4 +1,6 @@
 import os
 
 PREFIX = os.environ.get("INHOUSE_BOT_COMMAND_PREFIX") or "!"
-CONFIG_KEYS = ["voice"]
+CONFIG_OPTIONS = [
+    ("voice", "Allows the bot to create private voice channels for each team when a game is started.")
+]

--- a/inhouse_bot/common_utils/get_server_config.py
+++ b/inhouse_bot/common_utils/get_server_config.py
@@ -1,4 +1,4 @@
-from inhouse_bot.common_utils.constants import CONFIG_KEYS
+from inhouse_bot.common_utils.constants import CONFIG_OPTIONS
 from inhouse_bot.database_orm import ServerConfig
 from inhouse_bot.database_orm.session.session_handler import session_scope
 
@@ -8,7 +8,7 @@ def get_server_config(server_id: int, session) -> ServerConfig:
         session.query(ServerConfig)
         .select_from(ServerConfig)
         .filter(ServerConfig.server_id == server_id)
-    ).first() or None
+    ).one_or_none()
 
     if server_config is not None:
         return server_config
@@ -17,10 +17,10 @@ def get_server_config(server_id: int, session) -> ServerConfig:
     server_config = ServerConfig()
     server_config.server_id = server_id
     server_config.config = {}
-    for key in CONFIG_KEYS:
-        server_config.config[key] = False
+    for key in CONFIG_OPTIONS:
+        server_config.config[key[0]] = False
 
-    session.merge(server_config)
+    session.commit()
 
     return server_config
 


### PR DESCRIPTION
After reading about `session.merge()`, it doesn't seem necessary here. Using `session.commit()` fixed a bug related to merging sessions.

I've updated the help documentation and included the option to do `!admin config list`

![image](https://user-images.githubusercontent.com/1304934/111559072-15a07180-874d-11eb-9296-e826716da2bc.png)
