### PR TITLE
Adds a daily scheduler that allows for queue resets

### DIFF
--- a/inhouse_bot/common_utils/constants.py
+++ b/inhouse_bot/common_utils/constants.py
@@ -1,6 +1,10 @@
 import os
 
 PREFIX = os.environ.get("INHOUSE_BOT_COMMAND_PREFIX") or "!"
+# 12pm UTC is 5am PT
+QUEUE_RESET_TIME = os.environ.get("QUEUE_RESET_TIME") or "12:00"
+
 CONFIG_OPTIONS = [
+    ("queue_reset", f"Resets the queues daily at {QUEUE_RESET_TIME} UTC"),
     ("voice", "Allows the bot to create private voice channels for each team when a game is started.")
 ]

--- a/inhouse_bot/common_utils/get_server_config.py
+++ b/inhouse_bot/common_utils/get_server_config.py
@@ -21,6 +21,7 @@ def get_server_config(server_id: int, session) -> ServerConfig:
         server_config.config[key[0]] = False
 
     session.commit()
+    session.merge(server_config)
 
     return server_config
 


### PR DESCRIPTION
@mrtolkien This `session.merge()` stuff is really weird. Though I tested several times before, it looks like it was no longer creating the initial config object without the merge I added.

With this change, I've tested:

✔️ It works when there's no config and you're checking status
✔️ It works when there's no config and you're setting status for the first time
✔️ It works when the server is restarted and you're updating the config

So, I'm not 💯 on why this `session.merge` is needed the first time, but it seems it doesn't work without it.


The rest of this PR adds a new feature `queue_reset`. As part of this, I've added a `daily_jobs` function that will allow you to do other daily tasks at a certain time in the future. I spent a lot of time messing with and getting stuck on asyncio until I realized the discord client exposes the running event loop. 🤦 