### PR TITLE
Fix voice channel creation

### DIFF
--- a/inhouse_bot/cogs/queue_cog.py
+++ b/inhouse_bot/cogs/queue_cog.py
@@ -381,6 +381,7 @@ class QueueCog(commands.Cog, name="Queue"):
                 for participant in game.participants.values():
                     self.players_whose_last_game_got_cancelled[participant.player_id] = datetime.now()
 
+                await remove_voice_channels(ctx, game)
                 session.delete(game)
 
                 queue_channel_handler.mark_queue_related_message(

--- a/inhouse_bot/voice_channel_handler/voice_channel_handler.py
+++ b/inhouse_bot/voice_channel_handler/voice_channel_handler.py
@@ -38,7 +38,7 @@ async def create_voice_channels(ctx: commands.Context, game: Game):
         }
 
         for p in getattr(game.teams, side):
-            member = discord.Guild.get_member(ctx.guild, p.id)
+            member = discord.Guild.get_member(ctx.guild, p.player_id)
             if member is not None:
                 overwrites[member] = discord.PermissionOverwrite(read_messages=True)
 


### PR DESCRIPTION
The problem here was that I had previously mocked the creation of `GameParticipant` and in that mock accidentally called `player_id` `id`. 

During testing, I used the `!test queue` command to fill the queue, commented out the code to wait for the ready check so that a game would immediately start. This was a much better way to test, so I didn't have to rely on mocking some data. The voice channel handler also checks to make sure the member actually exists, so it's not failing when trying to add faked game participants. 